### PR TITLE
Fixing optional argument with doubledash (--)

### DIFF
--- a/docopt.coffee
+++ b/docopt.coffee
@@ -178,6 +178,8 @@ class Argument extends LeafPattern
 
     singleMatch: (left) ->
         for [n, pattern] in enumerate(left)
+            if pattern.value is '--'
+                return [null, null]
             if pattern.constructor is Argument
                 return [n, new Argument(@name, pattern.value)]
         return [null, null]

--- a/test/testcases.docopt
+++ b/test/testcases.docopt
@@ -938,6 +938,20 @@ NOT PART OF SECTION"""
 $ prog --foo
 {"--foo": true, "--bar": false}
 
+r"""Usage:
+ prog [<data>] [-- <args>...]
+ prog --bar
+NOT PART OF SECTION"""
+$ prog -- bare old
+{"<data>": null, "--": true, "<args>": ["bare", "old"], "--bar": false}
+
+r"""Usage:
+ prog [<data>] [-- <args>...]
+ prog --bar
+NOT PART OF SECTION"""
+$ prog value -- foo bar
+{"<data>": "value", "--": true, "<args>": ["foo", "bar"], "--bar": false}
+
 #
 # Options-section syntax
 #


### PR DESCRIPTION
When an use case has an optional argument followed by `--`, when that argument is skipped, its value is set as `--`.
I believe this is an unexpected behavior, so I've added a logic to avoid this conflict.

### Usage

```
Usage:
  naval ship [<name>] [-- <ship-instructions>... ]
```

### Before fix:

```shell
$ ship Guardian -- echo test
# OK: { "--": true, "<name>": "Guardian", "<ship-instructions>": ["echo", "test"], "ship": true }

$ ship -- echo test
# BAD: { "--": false, "<name>": "--", "<ship-instructions>": ["echo", "test"], "ship": true }
```

### After fix:

```shell
$ ship Guardian -- echo test
# OK: { "--": true, "<name>": "Guardian", "<ship-instructions>": ["echo", "test"], "ship": true }

$ ship -- echo test
# OK: { "--": true, "<name>": null, "<ship-instructions>": ["echo", "test"], "ship": true }
```

I've noticed the same issue happens on http://try.docopt.org. The above use case is available at http://goo.gl/xPwD6A