### PR TITLE
Reimplement native-prototype extensions as helper functions

### DIFF
--- a/docopt.coffee
+++ b/docopt.coffee
@@ -13,13 +13,12 @@ zip = (args...) ->
     for i in [0...length]
         arr[i] for arr in args
 
-String::partition = (separator) ->
-    self = this
-    if self.indexOf(separator) >= 0
-        parts = self.split(separator)
+partition = (string, separator) ->
+    if string.indexOf(separator) >= 0
+        parts = string.split(separator)
         return [parts[0], separator, parts.slice(1).join(separator)]
     else
-        return [String(self), '', '']
+        return [String(string), '', '']
 
 String::startsWith = (searchString, position) ->
     position = position || 0
@@ -214,7 +213,7 @@ class Option extends LeafPattern
 
     @parse: (option_description) ->
         [short, long, argcount, value] = [null, null, 0, false]
-        [options, _, description] = option_description.trim().partition('  ')
+        [options, _, description] = partition(option_description.trim(), '  ')
         options = options.replace /,|=/g, ' '
         for s in options._split()  # split on spaces
             if s.startsWith('--')
@@ -361,7 +360,7 @@ parse_shorts = (tokens, options) ->
 
 parse_long = (tokens, options) ->
     """long ::= '--' chars [ ( ' ' | '=' ) chars ] ;"""
-    [long, eq, value] = tokens.move().partition('=')
+    [long, eq, value] = partition(tokens.move(), '=')
     console.assert long.startsWith('--')
     value = null if (eq == value and value == '')
     similar = (o for o in options when o.long == long)
@@ -480,7 +479,7 @@ parse_defaults = (doc) ->
     defaults = []
     for s in parse_section('options:', doc)
         # FIXME corner case "bla: options: --foo"
-        [_, _, s] = s.partition(':')  # get rid of "options:"
+        [_, _, s] = partition(s, ':')  # get rid of "options:"
         split = ('\n' + s).split(new RegExp('\\n[ \\t]*(-\\S+?)')).slice(1)
         odd  = (v for v in split by 2)
         even = (v for v in split[1..] by 2)
@@ -490,7 +489,7 @@ parse_defaults = (doc) ->
     return defaults
 
 formal_usage = (section) ->
-    [_, _, section] = section.partition ':' # drop "usage:"
+    [_, _, section] = partition(section, ':') # drop "usage:"
     pu = section._split()
     return '( ' + ((if s == pu[0] then ') | (' else s) for s in pu[1..]).join(' ') + ' )'
 

--- a/docopt.coffee
+++ b/docopt.coffee
@@ -45,8 +45,8 @@ endsWith =
 _split = (string) ->
     string.trim().split(/\s+/).filter (i) -> i != ''
 
-String::isUpper = ->
-    /^[A-Z]+$/g.exec(this)
+isUpper = (string) ->
+    /^[A-Z]+$/g.exec(string)
 
 Number.isInteger = Number.isInteger || (value) ->
     return typeof value == "number" &&
@@ -458,7 +458,7 @@ parse_atom = (tokens, options) ->
         return parse_long tokens, options
     else if startsWith(token, '-') and token not in ['-', '--']
         return parse_shorts(tokens, options)
-    else if startsWith(token, '<') and endsWith(token, '>') or token.isUpper()
+    else if startsWith(token, '<') and endsWith(token, '>') or isUpper(token)
         return [new Argument(tokens.move())]
     else
         [new Command tokens.move()]

--- a/docopt.coffee
+++ b/docopt.coffee
@@ -42,8 +42,8 @@ endsWith =
             lastIndex = subjectString.indexOf(searchString, position)
             return lastIndex != -1 && lastIndex == position
 
-String::_split = ->
-    this.trim().split(/\s+/).filter (i) -> i != ''
+_split = (string) ->
+    string.trim().split(/\s+/).filter (i) -> i != ''
 
 String::isUpper = ->
     /^[A-Z]+$/g.exec(this)
@@ -97,7 +97,7 @@ class Pattern extends Object
                     if e.value is null
                         e.value = []
                     else if e.value.constructor isnt Array
-                        e.value = e.value._split()
+                        e.value = _split(e.value)
                 if e.constructor is Command or e.constructor is Option and e.argcount == 0
                     e.value = 0
         @
@@ -225,7 +225,7 @@ class Option extends LeafPattern
         [short, long, argcount, value] = [null, null, 0, false]
         [options, _, description] = partition(option_description.trim(), '  ')
         options = options.replace /,|=/g, ' '
-        for s in options._split()  # split on spaces
+        for s in _split(options)  # split on spaces
             if startsWith(s, '--')
                 long = s
             else if startsWith(s, '-')
@@ -315,7 +315,7 @@ class Either extends BranchPattern
 class Tokens extends Array
 
     constructor: (source, @error=DocoptExit) ->
-        stream = if source.constructor is String then source._split() else source
+        stream = if source.constructor is String then _split(source) else source
         @push.apply @, stream
 
     move: -> if @.length then [].shift.apply(@) else null
@@ -500,7 +500,7 @@ parse_defaults = (doc) ->
 
 formal_usage = (section) ->
     [_, _, section] = partition(section, ':') # drop "usage:"
-    pu = section._split()
+    pu = _split(section)
     return '( ' + ((if s == pu[0] then ') | (' else s) for s in pu[1..]).join(' ') + ' )'
 
 extras = (help, version, options, doc) ->

--- a/docopt.coffee
+++ b/docopt.coffee
@@ -48,7 +48,7 @@ _split = (string) ->
 isUpper = (string) ->
     /^[A-Z]+$/g.exec(string)
 
-Number.isInteger = Number.isInteger || (value) ->
+isInteger = Number.isInteger || (value) ->
     return typeof value == "number" &&
            isFinite(value) &&
            Math.floor(value) == value
@@ -153,15 +153,15 @@ class LeafPattern extends Pattern
             return [false, left, collected]
         left_ = left.slice(0, pos).concat(left.slice(pos + 1))
         same_name = (a for a in collected when a.name == @.name)
-        if Number.isInteger(@value) or @value instanceof Array
-            if Number.isInteger(@value)
+        if isInteger(@value) or @value instanceof Array
+            if isInteger(@value)
                 increment = 1
             else
                 increment = if typeof match.value == 'string' then [match.value] else match.value
             if not same_name.length
                 match.value = increment
                 return [true, left_, collected.concat(match)]
-            if Number.isInteger(@value)
+            if isInteger(@value)
                 same_name[0].value += increment
             else
                 same_name[0].value = [].concat(same_name[0].value, increment)

--- a/docopt.coffee
+++ b/docopt.coffee
@@ -29,13 +29,18 @@ startsWith =
             position = position || 0
             return string.lastIndexOf(searchString, position) == position
 
-String::endsWith = (searchString, position) ->
-    subjectString = this.toString()
-    if (position == undefined || position > subjectString.length)
-        position = subjectString.length
-    position -= searchString.length
-    lastIndex = subjectString.indexOf(searchString, position)
-    return lastIndex != -1 && lastIndex == position
+endsWith =
+    if String.prototype.endsWith
+        (string, searchString, position) ->
+            return string.endsWith(searchString, position)
+    else
+        (string, searchString, position) ->
+            subjectString = string.toString()
+            if (position == undefined || position > subjectString.length)
+                position = subjectString.length
+            position -= searchString.length
+            lastIndex = subjectString.indexOf(searchString, position)
+            return lastIndex != -1 && lastIndex == position
 
 String::_split = ->
     this.trim().split(/\s+/).filter (i) -> i != ''
@@ -453,7 +458,7 @@ parse_atom = (tokens, options) ->
         return parse_long tokens, options
     else if startsWith(token, '-') and token not in ['-', '--']
         return parse_shorts(tokens, options)
-    else if startsWith(token, '<') and token.endsWith('>') or token.isUpper()
+    else if startsWith(token, '<') and endsWith(token, '>') or token.isUpper()
         return [new Argument(tokens.move())]
     else
         [new Command tokens.move()]


### PR DESCRIPTION
This small pull request refactors to avoid extending native prototypes `String` and `Number` by reimplementing those methods as helper functions.  `startsWith` and `endsWith` were wrapped to use the built-in ES2015 standard library implementations when available.

This approach leaves then native prototypes and method implementations as they come from the VM, reducing the risk of performance losses in the case of methods now available in ES6, and conflicts in the case of add-ons like `_split()` for `String`.

I've tried my best to hew to the pervading CoffeScript style.  Hopefully that will continue to make it easy to compare CoffeeScript and original Python code.