### PR TITLE
Configure Travis CI to test on Node.js 4, 6, and current

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - "0.11"
   - "0.10"
   - "iojs"
+  - "4"
+  - "6"
+  - "node"
 script:
   - npm run test
   - npm run lint


### PR DESCRIPTION
"argon" and "boron" are LTS releases. "Node" should get the most current lease, presently 8.x.y.