### PR TITLE
Bump npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docopt",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "author": "Vladimir Keleshev <vladimir@keleshev.com>",
   "contributors": [
     {


### PR DESCRIPTION
Hi, I just wanted to request an npm release--not sure this is the version you want, if you are ready for a release...

(I'm personally requesting this as my license checker licensee.js doesn't handle the old-style `package.json` `license` objects at present.)